### PR TITLE
fix: prevent navigation menu flash for authenticated users

### DIFF
--- a/public/app/account.html
+++ b/public/app/account.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Join Now - NSC Social Day Cruising</title>
+    <!-- Auth init MUST run before page renders to prevent navigation jump -->
+    <script src="js/auth-init.js"></script>
     <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
@@ -19,7 +21,23 @@
                 <ul id="main-nav">
                     <li><a href="index.html">Home</a></li>
                     <li><a href="events.html">Events</a></li>
-                    <li><a href="account.html" class="active">Join Now</a></li>
+
+                    <!-- Unauthenticated nav -->
+                    <li class="nav-unauthenticated">
+                        <a href="account.html" class="active">Join Now</a>
+                    </li>
+
+                    <!-- Authenticated nav -->
+                    <li class="nav-authenticated">
+                        <a href="dashboard.html">Dashboard</a>
+                    </li>
+                    <li class="nav-authenticated user-greeting">
+                        <span>Hi, <span class="user-name">...</span>!</span>
+                    </li>
+                    <li class="nav-authenticated">
+                        <a href="#" class="sign-out-btn">Sign Out</a>
+                    </li>
+
                     <li><a href="faq.html">FAQ</a></li>
                 </ul>
             </nav>

--- a/public/app/account_boat.html
+++ b/public/app/account_boat.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Boat Owner Registration - NSC Social Day Cruising</title>
+    <!-- Auth init MUST run before page renders to prevent navigation jump -->
+    <script src="js/auth-init.js"></script>
     <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
@@ -19,7 +21,23 @@
                 <ul id="main-nav">
                     <li><a href="index.html">Home</a></li>
                     <li><a href="events.html">Events</a></li>
-                    <li><a href="account.html" class="active">Join Now</a></li>
+
+                    <!-- Unauthenticated nav -->
+                    <li class="nav-unauthenticated">
+                        <a href="account.html" class="active">Join Now</a>
+                    </li>
+
+                    <!-- Authenticated nav -->
+                    <li class="nav-authenticated">
+                        <a href="dashboard.html">Dashboard</a>
+                    </li>
+                    <li class="nav-authenticated user-greeting">
+                        <span>Hi, <span class="user-name">...</span>!</span>
+                    </li>
+                    <li class="nav-authenticated">
+                        <a href="#" class="sign-out-btn">Sign Out</a>
+                    </li>
+
                     <li><a href="faq.html">FAQ</a></li>
                 </ul>
             </nav>

--- a/public/app/account_crew.html
+++ b/public/app/account_crew.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Crew Registration - NSC Social Day Cruising</title>
+    <!-- Auth init MUST run before page renders to prevent navigation jump -->
+    <script src="js/auth-init.js"></script>
     <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
@@ -19,7 +21,23 @@
                 <ul id="main-nav">
                     <li><a href="index.html">Home</a></li>
                     <li><a href="events.html">Events</a></li>
-                    <li><a href="account.html" class="active">Join Now</a></li>
+
+                    <!-- Unauthenticated nav -->
+                    <li class="nav-unauthenticated">
+                        <a href="account.html" class="active">Join Now</a>
+                    </li>
+
+                    <!-- Authenticated nav -->
+                    <li class="nav-authenticated">
+                        <a href="dashboard.html">Dashboard</a>
+                    </li>
+                    <li class="nav-authenticated user-greeting">
+                        <span>Hi, <span class="user-name">...</span>!</span>
+                    </li>
+                    <li class="nav-authenticated">
+                        <a href="#" class="sign-out-btn">Sign Out</a>
+                    </li>
+
                     <li><a href="faq.html">FAQ</a></li>
                 </ul>
             </nav>

--- a/public/app/css/styles.css
+++ b/public/app/css/styles.css
@@ -118,6 +118,21 @@ nav a:hover {
   color: var(--teal);
 }
 
+/* ===================================
+   Authentication-based Navigation Visibility
+   Prevents flash of unauthenticated content (FOUC)
+   =================================== */
+
+/* Hide authenticated-only nav items when user is not authenticated */
+html.unauthenticated .nav-authenticated {
+  display: none !important;
+}
+
+/* Hide unauthenticated-only nav items when user is authenticated */
+html.authenticated .nav-unauthenticated {
+  display: none !important;
+}
+
 /* Hamburger Menu Button */
 .hamburger {
   display: none;
@@ -1089,6 +1104,7 @@ nav .user-greeting {
   font-weight: 500;
   padding: 0 1rem;
   font-size: 0.95rem;
+  white-space: nowrap; /* Prevent wrapping "Hi, Name!" across multiple lines */
 }
 
 /* Responsive adjustments for dashboard */

--- a/public/app/dashboard.html
+++ b/public/app/dashboard.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>My Dashboard - NSC Social Day Cruising</title>
+    <!-- Auth init MUST run before page renders to prevent navigation jump -->
+    <script src="js/auth-init.js"></script>
     <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
@@ -19,10 +21,24 @@
                 <ul id="main-nav">
                     <li><a href="index.html">Home</a></li>
                     <li><a href="events.html">Events</a></li>
-                    <li><a href="dashboard.html" class="active">Dashboard</a></li>
+
+                    <!-- Unauthenticated nav -->
+                    <li class="nav-unauthenticated">
+                        <a href="account.html">Join Now</a>
+                    </li>
+
+                    <!-- Authenticated nav -->
+                    <li class="nav-authenticated">
+                        <a href="dashboard.html" class="active">Dashboard</a>
+                    </li>
+                    <li class="nav-authenticated user-greeting">
+                        <span>Hi, <span class="user-name">...</span>!</span>
+                    </li>
+                    <li class="nav-authenticated">
+                        <a href="#" class="sign-out-btn">Sign Out</a>
+                    </li>
+
                     <li><a href="faq.html">FAQ</a></li>
-                    <li><span class="user-greeting">Hi, <span id="nav-username"></span>!</span></li>
-                    <li><a href="#" onclick="signOut(); return false;" class="sign-out-btn">Sign Out</a></li>
                 </ul>
             </nav>
         </div>

--- a/public/app/edit_profile.html
+++ b/public/app/edit_profile.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Edit Profile - NSC Social Day Cruising</title>
+    <!-- Auth init MUST run before page renders to prevent navigation jump -->
+    <script src="js/auth-init.js"></script>
     <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
@@ -19,10 +21,24 @@
                 <ul id="main-nav">
                     <li><a href="index.html">Home</a></li>
                     <li><a href="events.html">Events</a></li>
-                    <li><a href="dashboard.html" class="active">Dashboard</a></li>
+
+                    <!-- Unauthenticated nav -->
+                    <li class="nav-unauthenticated">
+                        <a href="account.html">Join Now</a>
+                    </li>
+
+                    <!-- Authenticated nav -->
+                    <li class="nav-authenticated">
+                        <a href="dashboard.html" class="active">Dashboard</a>
+                    </li>
+                    <li class="nav-authenticated user-greeting">
+                        <span>Hi, <span class="user-name">...</span>!</span>
+                    </li>
+                    <li class="nav-authenticated">
+                        <a href="#" class="sign-out-btn">Sign Out</a>
+                    </li>
+
                     <li><a href="faq.html">FAQ</a></li>
-                    <li><span class="user-greeting">Hi, <span id="nav-username"></span>!</span></li>
-                    <li><a href="#" onclick="signOut(); return false;" class="sign-out-btn">Sign Out</a></li>
                 </ul>
             </nav>
         </div>

--- a/public/app/events.html
+++ b/public/app/events.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Events Schedule - NSC Social Day Cruising</title>
+    <!-- Auth init MUST run before page renders to prevent navigation jump -->
+    <script src="js/auth-init.js"></script>
     <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
@@ -19,7 +21,23 @@
                 <ul id="main-nav">
                     <li><a href="index.html">Home</a></li>
                     <li><a href="events.html" class="active">Events</a></li>
-                    <li id="nav-account"><a href="account.html">Join Now</a></li>
+
+                    <!-- Unauthenticated nav -->
+                    <li class="nav-unauthenticated">
+                        <a href="account.html">Join Now</a>
+                    </li>
+
+                    <!-- Authenticated nav -->
+                    <li class="nav-authenticated">
+                        <a href="dashboard.html">Dashboard</a>
+                    </li>
+                    <li class="nav-authenticated user-greeting">
+                        <span>Hi, <span class="user-name">...</span>!</span>
+                    </li>
+                    <li class="nav-authenticated">
+                        <a href="#" class="sign-out-btn">Sign Out</a>
+                    </li>
+
                     <li><a href="faq.html">FAQ</a></li>
                 </ul>
             </nav>

--- a/public/app/faq.html
+++ b/public/app/faq.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>FAQ - NSC Social Day Cruising</title>
+    <!-- Auth init MUST run before page renders to prevent navigation jump -->
+    <script src="js/auth-init.js"></script>
     <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
@@ -19,7 +21,23 @@
                 <ul id="main-nav">
                     <li><a href="index.html">Home</a></li>
                     <li><a href="events.html">Events</a></li>
-                    <li id="nav-account"><a href="account.html">Join Now</a></li>
+
+                    <!-- Unauthenticated nav -->
+                    <li class="nav-unauthenticated">
+                        <a href="account.html">Join Now</a>
+                    </li>
+
+                    <!-- Authenticated nav -->
+                    <li class="nav-authenticated">
+                        <a href="dashboard.html">Dashboard</a>
+                    </li>
+                    <li class="nav-authenticated user-greeting">
+                        <span>Hi, <span class="user-name">...</span>!</span>
+                    </li>
+                    <li class="nav-authenticated">
+                        <a href="#" class="sign-out-btn">Sign Out</a>
+                    </li>
+
                     <li><a href="faq.html" class="active">FAQ</a></li>
                 </ul>
             </nav>

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NSC Social Day Cruising - Sail Together!</title>
+    <!-- Auth init MUST run before page renders to prevent navigation jump -->
+    <script src="js/auth-init.js"></script>
     <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
@@ -19,7 +21,23 @@
                 <ul id="main-nav">
                     <li><a href="index.html" class="active">Home</a></li>
                     <li><a href="events.html">Events</a></li>
-                    <li id="nav-account"><a href="account.html">Join Now</a></li>
+
+                    <!-- Unauthenticated nav -->
+                    <li class="nav-unauthenticated">
+                        <a href="account.html">Join Now</a>
+                    </li>
+
+                    <!-- Authenticated nav -->
+                    <li class="nav-authenticated">
+                        <a href="dashboard.html">Dashboard</a>
+                    </li>
+                    <li class="nav-authenticated user-greeting">
+                        <span>Hi, <span class="user-name">...</span>!</span>
+                    </li>
+                    <li class="nav-authenticated">
+                        <a href="#" class="sign-out-btn">Sign Out</a>
+                    </li>
+
                     <li><a href="faq.html">FAQ</a></li>
                 </ul>
             </nav>

--- a/public/app/js/auth-init.js
+++ b/public/app/js/auth-init.js
@@ -1,0 +1,27 @@
+/**
+ * Synchronous Authentication Initializer
+ *
+ * This runs as a blocking script in <head> to set auth state before page renders.
+ * Prevents flash of unauthenticated navigation (FOUC).
+ *
+ * IMPORTANT: This script MUST be included before the stylesheet in <head>:
+ * <script src="js/auth-init.js"></script>
+ * <link rel="stylesheet" href="css/styles.css">
+ *
+ * This script checks sessionStorage synchronously (no async/await) to determine
+ * if a JWT token exists, then adds a CSS class to <html> element that controls
+ * which navigation items are visible via CSS rules.
+ */
+(function() {
+    const TOKEN_KEY = 'nsc_auth_token';
+
+    // Synchronous check - sessionStorage.getItem() is NOT async
+    const hasToken = sessionStorage.getItem(TOKEN_KEY) !== null;
+
+    // Add class to <html> element before page renders
+    if (hasToken) {
+        document.documentElement.classList.add('authenticated');
+    } else {
+        document.documentElement.classList.add('unauthenticated');
+    }
+})();

--- a/public/app/js/navigationService.js
+++ b/public/app/js/navigationService.js
@@ -9,10 +9,14 @@
 /**
  * Updates navigation UI when user is authenticated
  *
- * This handles:
- * - Changing nav-account to show Dashboard link
- * - Adding user greeting with first name
- * - Adding sign out button to navigation
+ * NOTE: As of the anti-FOUC refactor, the navigation structure is pre-rendered
+ * in HTML with both authenticated and unauthenticated items. CSS classes
+ * (.nav-authenticated, .nav-unauthenticated) control visibility based on the
+ * auth state set by auth-init.js.
+ *
+ * This function now ONLY:
+ * - Fills in the user's first name (replaces "..." placeholder)
+ * - Attaches the sign-out event handler
  *
  * @param {Object} user - User object from AuthService.getCurrentUser()
  * @param {Function} signOut - Sign out function from AuthService
@@ -33,30 +37,24 @@ export function updateAuthenticatedNavigation(user, signOut) {
         return false;
     }
 
-    const navAccount = document.getElementById('nav-account');
-    const mainNav = document.getElementById('main-nav');
-
-    if (!navAccount || !mainNav) {
-        console.warn('NavigationService: Required DOM elements not found (nav-account, main-nav)');
-        return false;
+    // Update user's first name in the greeting (nav structure already exists in HTML)
+    const userNameSpan = document.querySelector('.user-name');
+    if (userNameSpan) {
+        userNameSpan.textContent = user.profile.firstName;
+    } else {
+        console.warn('NavigationService: .user-name element not found');
     }
 
-    // Update nav-account to show Dashboard link
-    navAccount.innerHTML = '<a href="dashboard.html">Dashboard</a>';
-
-    // Add user greeting
-    const userGreeting = document.createElement('li');
-    userGreeting.innerHTML = '<span class="user-greeting">Hi, <span id="nav-username">' + user.profile.firstName; + '</span>!</span>';
-    mainNav.appendChild(userGreeting);
-
-    // Add sign out button
-    const signOutLi = document.createElement('li');
-    signOutLi.innerHTML = '<a href="#" class="sign-out-btn">Sign Out</a>';
-    signOutLi.querySelector('a').addEventListener('click', (e) => {
-        e.preventDefault();
-        signOut();
-    });
-    mainNav.appendChild(signOutLi);
+    // Attach sign-out event handler
+    const signOutBtn = document.querySelector('.sign-out-btn');
+    if (signOutBtn) {
+        signOutBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            signOut();
+        });
+    } else {
+        console.warn('NavigationService: .sign-out-btn element not found');
+    }
 
     return true;
 }

--- a/public/app/js/pages/dashboard-page.js
+++ b/public/app/js/pages/dashboard-page.js
@@ -4,14 +4,12 @@
  */
 
 import { requireAuth, getCurrentUser, signOut } from '../authService.js';
+import { updateAuthenticatedNavigation } from '../navigationService.js';
 import { getAllEvents, isDeadlinePassed } from '../eventService.js';
 import { updateEventAvailability } from '../userService.js';
 import { get } from '../apiService.js';
 import { API_CONFIG } from '../config.js';
 import { showSuccess, showError, showInfo } from '../toastService.js';
-
-// Make signOut available globally for onclick handlers
-window.signOut = signOut;
 
 // Require authentication
 if (!requireAuth()) {
@@ -29,9 +27,11 @@ if (!user) {
 
 console.log('User loaded successfully:', user.email);
 
-// Populate username in hero and nav
+// Update navigation with user's name and attach sign-out handler
+updateAuthenticatedNavigation(user, signOut);
+
+// Populate username in hero
 document.getElementById('hero-username').textContent = user.profile.firstName;
-document.getElementById('nav-username').textContent = user.profile.firstName;
 
 // Populate account badge
 const badge = document.getElementById('account-badge');

--- a/public/app/js/pages/edit-profile-page.js
+++ b/public/app/js/pages/edit-profile-page.js
@@ -4,13 +4,11 @@
  */
 
 import { requireAuth, getCurrentUser, signOut } from '../authService.js';
+import { updateAuthenticatedNavigation } from '../navigationService.js';
 import { updateUser } from '../userService.js';
 import { hashPassword } from '../authService.js';
 import { validatePassword, getPasswordRequirementsHTML } from '../passwordValidator.js';
 import { showSuccess, showError } from '../toastService.js';
-
-// Make signOut available globally for onclick handlers
-window.signOut = signOut;
 
 // Require authentication
 if (!requireAuth()) {
@@ -23,8 +21,8 @@ if (!user) {
     window.location.href = 'signin.html';
 }
 
-// Populate username in nav
-document.getElementById('nav-username').textContent = user.profile.firstName;
+// Update navigation with user's name and attach sign-out handler
+updateAuthenticatedNavigation(user, signOut);
 
 // Build form based on account type
 const formContent = document.getElementById('form-content');

--- a/public/app/signin.html
+++ b/public/app/signin.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sign In - NSC Social Day Cruising</title>
+    <!-- Auth init MUST run before page renders to prevent navigation jump -->
+    <script src="js/auth-init.js"></script>
     <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
@@ -19,7 +21,23 @@
                 <ul id="main-nav">
                     <li><a href="index.html">Home</a></li>
                     <li><a href="events.html">Events</a></li>
-                    <li><a href="account.html">Join Now</a></li>
+
+                    <!-- Unauthenticated nav -->
+                    <li class="nav-unauthenticated">
+                        <a href="account.html">Join Now</a>
+                    </li>
+
+                    <!-- Authenticated nav -->
+                    <li class="nav-authenticated">
+                        <a href="dashboard.html">Dashboard</a>
+                    </li>
+                    <li class="nav-authenticated user-greeting">
+                        <span>Hi, <span class="user-name">...</span>!</span>
+                    </li>
+                    <li class="nav-authenticated">
+                        <a href="#" class="sign-out-btn">Sign Out</a>
+                    </li>
+
                     <li><a href="faq.html">FAQ</a></li>
                 </ul>
             </nav>


### PR DESCRIPTION
Implemented synchronous authentication check to eliminate FOUC (Flash of Unauthenticated Content) when navigating between pages as an authenticated user.

Changes:
- Created auth-init.js: synchronous script that checks sessionStorage for JWT token and adds 'authenticated' or 'unauthenticated' class to <html> element before page renders
- Updated all HTML pages to include auth-init.js script before stylesheet
- Restructured navigation HTML to include both authenticated and unauthenticated menu items with CSS classes for visibility control
- Added CSS rules to show/hide navigation items based on authentication state
- Simplified navigationService.js to only update user's name and attach sign-out handler (no longer rebuilds entire navigation)
- Updated dashboard-page.js and edit-profile-page.js to use navigationService instead of direct DOM manipulation
- Added white-space: nowrap to user greeting to prevent multi-line wrapping

Result: Navigation menu now displays correctly from initial page load with no visible jumping or flashing when authenticated users navigate between pages.

Fixes #8 